### PR TITLE
fix: support GitHub Pages base path

### DIFF
--- a/src/lib/components/Changelog.svelte
+++ b/src/lib/components/Changelog.svelte
@@ -14,7 +14,7 @@
         }
 
         li {
-            list-svelte:head-type: disc;
+            list-style-type: disc;
         }
         ul {
             list-style-type: disc;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -41,9 +41,9 @@
 <header class="fixed top-0 left-0 z-[100] w-full bg-[#111] py-3.5">
 	<div class="mx-auto w-11/12 max-w-full">
 		<nav class="flex items-center justify-between">
-			<a href="/" class="flex items-center">
-				<img src="{base}/img/bruce.png" alt="Bruce Logo" class="h-[50px]" />
-			</a>
+                       <a href={base} class="flex items-center">
+                               <img src="{base}/img/bruce.png" alt="Bruce Logo" class="h-[50px]" />
+                       </a>
 			<button
 				class="inline-block text-white hover:text-purple-500 lg:hidden"
 				onclick={() => (navOpen = true)}
@@ -51,17 +51,17 @@
 				aria-label="Open navigation">☰</button
 			>
 			<div class="hidden items-center gap-5 lg:flex">
-				<NavLink href="/" selected={$current_page == Page.Home}>Home</NavLink>
-				<NavLink href="https://github.com/pr3y/Bruce" target="_blank">GitHub</NavLink>
-				<NavLink href="{base}/flasher" variant="install">Install</NavLink>
-				<NavLink href="https://github.com/pr3y/Bruce/wiki" target="_blank">Docs</NavLink>
-				<NavLink href="{base}/store" selected={$current_page == Page.AppStore}>App Store</NavLink>
-				<NavLink href="{base}/build_theme.html">Theme Builder</NavLink>
+                               <NavLink href={base} selected={$current_page == Page.Home}>Home</NavLink>
+                               <NavLink href="https://github.com/pr3y/Bruce" target="_blank">GitHub</NavLink>
+                               <NavLink href="{base}/flasher" variant="install">Install</NavLink>
+                               <NavLink href="https://github.com/pr3y/Bruce/wiki" target="_blank">Docs</NavLink>
+                               <NavLink href="{base}/store" selected={$current_page == Page.AppStore}>App Store</NavLink>
+                               <NavLink href="{base}/build_theme.html">Theme Builder</NavLink>
 				<NavLink href="{base}/my_bruce" selected={$current_page == Page.MyBruce}>Bruce Lab</NavLink>
 				<NavLink href="{base}/boards">Boards</NavLink>
 				<!-- <Dropdown title="Bruce Lab" links={bruce_lab_links}></Dropdown> -->
-				<!-- <NavLink href="/boards">Boards</NavLink>
-				<NavLink href="/community">Community</NavLink> -->
+                               <!-- <NavLink href="{base}/boards">Boards</NavLink>
+                               <NavLink href="{base}/community">Community</NavLink> -->
 				<NavLink href="{base}/donate" selected={$current_page == Page.Donate}>Donate</NavLink>
 			</div>
 			{#if navOpen}

--- a/src/routes/flasher/+page.svelte
+++ b/src/routes/flasher/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-	import { current_page, Page } from '$lib/store';
-	import manifests from '$lib/data/manifests.json';
-	import SectionBackground from '$lib/components/SectionBackground.svelte';
+        import { current_page, Page } from '$lib/store';
+        import manifests from '$lib/data/manifests.json';
+        import SectionBackground from '$lib/components/SectionBackground.svelte';
+        import { base } from '$app/paths';
 
 	$current_page = Page.Flasher;
 	let selectedVersion = $state('Last');
@@ -47,8 +48,8 @@
 </script>
 
 <svelte:head>
-	<script type="module" src="/esp-web-tools-8.0.1/dist/web/install-button.js?module"></script>
-</svelte:head>
+        <script type="module" src="{base}/esp-web-tools-8.0.1/dist/web/install-button.js?module"></script>
+        </svelte:head>
 
 <section class="relative flex h-[500px] w-full flex-col overflow-hidden pr-4 pl-4 md:flex-row">
 	<SectionBackground />

--- a/static/build_theme.html
+++ b/static/build_theme.html
@@ -483,8 +483,8 @@
 <body>
     <div class="container">
         <header class="header">
-            <a href="/" class="logo">
-                <img src="/img/bruce.png" alt="Bruce Logo">
+            <a href="./" class="logo">
+                <img src="./img/bruce.png" alt="Bruce Logo">
             </a>
             <h1>Bruce Theme Builder</h1>
 


### PR DESCRIPTION
## Summary
- prefix internal links with SvelteKit base path
- load flasher assets relative to base directory
- correct static theme builder links and changelog styles

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4ee24d1f8832c983fbb274b5d87ca